### PR TITLE
Select keyboard layout from systemd-bootd

### DIFF
--- a/toslive/Jenkinsfile
+++ b/toslive/Jenkinsfile
@@ -14,7 +14,7 @@ void setBuildStatus(String message, String state) {
 
 node('archlinux') {
   try {
-     stage('pull') { 
+     stage('pull') {
           git "https://github.com/ODEX-TOS/tos-live.git"
           sh "cd toslive && ./version_builder.sh"
       }
@@ -55,7 +55,7 @@ node('archlinux') {
       }
       // Upload iso's to remote repository
       stage('upload') {
-          sh "cd repo && sh upload.sh -y" 
+          sh "cd repo && sh upload.sh -y"
       }
       stage("set success"){
          setBuildStatus("Build succeeded", "SUCCESS");

--- a/toslive/Jenkinsfile
+++ b/toslive/Jenkinsfile
@@ -29,34 +29,10 @@ node('archlinux') {
               echo "First build failed, let's retry."
               echo "This probably happend because our repository has been updated"
               retry(2) {
-                 sh "cd toslive && sudo ./start.sh -s && pwd"
+                 sh "sudo rm -rf toslive/work && cd toslive && sudo ./start.sh -s && pwd"
               }
            }
       }
-      // Build tos client edition
-      /*stage('client'){
-          try {
-              sh "cd toslive && sudo ./start.sh -g && pwd" // run start.sh as a root user since the live iso chroot is a root user
-           } catch(error) {
-              echo "Second build failed, let's retry."
-              echo "This probably happend because our repository has been updated"
-              retry(2) {
-                 sh "cd toslive && sudo ./start.sh -g && pwd"
-              }
-           }
-      }*/
-      // Build tos client edition
-      /*stage('kde'){
-          try {
-              sh "cd toslive && sudo ./start.sh -k && pwd" // run start.sh as a root user since the live iso chroot is a root user
-           } catch(error) {
-              echo "Second build failed, let's retry."
-              echo "This probably happend because our repository has been updated"
-              retry(2) {
-                 sh "cd toslive && sudo ./start.sh -k && pwd"
-              }
-           }
-      }*/
       // Build tos awesome edition
       stage('awesome'){
           try {
@@ -65,54 +41,7 @@ node('archlinux') {
               echo "Second build failed, let's retry."
               echo "This probably happend because our repository has been updated"
               retry(2) {
-                 sh "cd toslive && sudo ./start.sh -awesome && pwd"
-              }
-           }
-      }
-      // Build tos server edition with azerty layout
-      stage('server azerty'){
-           try {
-              sh "cd toslive && sudo ./start.sh -s -a && pwd" // run start.sh as a root user since the live iso chroot is a root user
-           } catch(error) {
-              echo "First build failed, let's retry."
-              echo "This probably happend because our repository has been updated"
-              retry(2) {
-                 sh "cd toslive && sudo ./start.sh -s -a && pwd"
-              }
-           }    }
-      // Build tos client edition with azerty layout
-      /*stage('client azerty'){
-          try {
-              sh "cd toslive && sudo ./start.sh -g -a && pwd" // run start.sh as a root user since the live iso chroot is a root user
-           } catch(error) {
-              echo "First build failed, let's retry."
-              echo "This probably happend because our repository has been updated"
-              retry(2) {
-                 sh "cd toslive && sudo ./start.sh -g -a && pwd"
-              }
-           }
-      }*/
-      // Build tos client edition
-      /*stage('kde azerty'){
-          try {
-              sh "cd toslive && sudo ./start.sh -k -a && pwd" // run start.sh as a root user since the live iso chroot is a root user
-           } catch(error) {
-              echo "Second build failed, let's retry."
-              echo "This probably happend because our repository has been updated"
-              retry(2) {
-                 sh "cd toslive && sudo ./start.sh -k -a && pwd"
-              }
-           }
-      }*/
-      // Build tos client edition
-      stage('awesome azerty'){
-          try {
-              sh "cd toslive && sudo ./start.sh -awesome -a && pwd" // run start.sh as a root user since the live iso chroot is a root user
-           } catch(error) {
-              echo "Second build failed, let's retry."
-              echo "This probably happend because our repository has been updated"
-              retry(2) {
-                 sh "cd toslive && sudo ./start.sh -awesome -a && pwd"
+                 sh "sudo rm -rf toslive/work && cd toslive && sudo ./start.sh -awesome && pwd"
               }
            }
       }

--- a/toslive/customize_airootfs.sh_awesome
+++ b/toslive/customize_airootfs.sh_awesome
@@ -22,7 +22,6 @@ sed -i 's/#\(HandleSuspendKey=\)suspend/\1ignore/' /etc/systemd/logind.conf
 sed -i 's/#\(HandleHibernateKey=\)hibernate/\1ignore/' /etc/systemd/logind.conf
 sed -i 's/#\(HandleLidSwitch=\)suspend/\1ignore/' /etc/systemd/logind.conf
 
-
 systemctl enable pacman-init.service choose-mirror.service
 systemctl set-default multi-user.target
 systemctl enable NetworkManager
@@ -54,9 +53,8 @@ git clone https://github.com/zsh-users/zsh-completions.git /root/.oh-my-zsh/cust
 git clone https://github.com/ODEX-TOS/zsh-load /root/.oh-my-zsh/load
 curl https://raw.githubusercontent.com/ODEX-TOS/tos-live/master/_tos >/root/.oh-my-zsh/custom/plugins/zsh-completions/src/_tos
 
-
 # get the keymapping from /proc/cmdline
-cat <<EOF >> /root/.profile
+cat <<EOF >>/root/.profile
 KEY=\$(grep -o "tos.key=[a-zA-Z0-9\-]*" /proc/cmdline | cut -d "=" -f2)
 LOADKEY=\$(grep -o "tos.loadkeys=[a-zA-Z0-9\-]*" /proc/cmdline | cut -d "=" -f2)
 # these two env variables hold keyboard information
@@ -74,7 +72,7 @@ git clone https://github.com/denysdovhan/spaceship-prompt.git "/root/.oh-my-zsh/
 ln -s "/root/.oh-my-zsh/custom/themes/spaceship-prompt/spaceship.zsh-theme" "/root/.oh-my-zsh/custom/themes/spaceship.zsh-theme"
 
 # update zshrc file to the official tos version
-cp /root/.config/.zshrc /root/.zshrc 
+cp /root/.config/.zshrc /root/.zshrc
 
 printf "\nif [[ \$(tty) == '/dev/tty1' ]]; then\n startx\n fi" >>/root/.zshrc
 printf "\nif [[ \$(tty) == '/dev/tty1' ]]; then\n startx\n fi" >>/root/.bashrc
@@ -90,10 +88,10 @@ sed -i 's/"glx";/"xrender";/g' /etc/xdg/awesome/configuration/picom.conf
 sed -i 's/"glx";/"xrender";/g' /root/.config/picom.conf
 # enable sysrq triggers
 mkdir -p /etc/sysctl.d/
-echo "kernel.sysrq = 511" >> /etc/sysctl.d/99-sysctl.conf
+echo "kernel.sysrq = 511" >>/etc/sysctl.d/99-sysctl.conf
 
 if [[ -f "/etc/mkinitcpio.d/linux.preset" ]]; then
-        rm /etc/mkinitcpio.d/linux.preset
+  rm /etc/mkinitcpio.d/linux.preset
 fi
 pacman-key --init
 pacman-key --populate archlinux
@@ -101,4 +99,4 @@ pacman-key --populate tos
 
 # custom version of theme file
 mkdir -p /root/.config/tos
-printf "on\ntime=1800\nfull=false\n/usr/share/backgrounds/tos/default.png\n" > /root/.config/tos/theme
+printf "on\ntime=1800\nfull=false\n/usr/share/backgrounds/tos/default.png\n" >/root/.config/tos/theme

--- a/toslive/customize_airootfs.sh_awesome
+++ b/toslive/customize_airootfs.sh_awesome
@@ -2,7 +2,6 @@
 
 set -e -u
 
-azerty="0"
 version="v0.0.0"
 
 sed -i 's/#\(en_US\.UTF-8\)/\1/' /etc/locale.gen
@@ -22,9 +21,7 @@ sed -i 's/#\(Storage=\)auto/\1volatile/' /etc/systemd/journald.conf
 sed -i 's/#\(HandleSuspendKey=\)suspend/\1ignore/' /etc/systemd/logind.conf
 sed -i 's/#\(HandleHibernateKey=\)hibernate/\1ignore/' /etc/systemd/logind.conf
 sed -i 's/#\(HandleLidSwitch=\)suspend/\1ignore/' /etc/systemd/logind.conf
-if [[ "$azerty" == "1" ]]; then
-  loadkeys be-latin1
-fi
+
 
 systemctl enable pacman-init.service choose-mirror.service
 systemctl set-default multi-user.target
@@ -39,13 +36,9 @@ curl https://raw.githubusercontent.com/ODEX-TOS/tools/master/tosinstall -o /root
 chmod +x /root/tosinstall
 
 rm -rf .oh-my-zsh
-if [[ "$azerty" == "0" ]]; then
-  sed -i 's;set $KEY be;set $KEY us;' /root/.config/i3/config
-  sed -i 's;set $KEY be;set $KEY us;' /root/.config/sway/config
-  printf 'KEYMAP=us' >/etc/vconsole.conf
-else
-  printf 'KEYMAP=be-latin1' >/etc/vconsole.conf
-fi
+
+# set the default keymap to us (get overridden by .profile)
+printf 'KEYMAP=us' >/etc/vconsole.conf
 
 curl https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh -o install.sh
 export RUNZSH=no
@@ -61,12 +54,19 @@ git clone https://github.com/zsh-users/zsh-completions.git /root/.oh-my-zsh/cust
 git clone https://github.com/ODEX-TOS/zsh-load /root/.oh-my-zsh/load
 curl https://raw.githubusercontent.com/ODEX-TOS/tos-live/master/_tos >/root/.oh-my-zsh/custom/plugins/zsh-completions/src/_tos
 
-if [[ "$azerty" == "1" ]]; then
-  echo "loadkeys be-latin1" >>/root/.profile
-  echo "export KEY='be'" >>/root/.profile
-else
-  echo "export KEY='us'" >>/root/.profile
-fi
+
+# get the keymapping from /proc/cmdline
+cat <<EOF >> /root/.profile
+KEY=\$(grep -o "tos.key=[a-zA-Z0-9\-]*" /proc/cmdline | cut -d "=" -f2)
+LOADKEY=\$(grep -o "tos.loadkeys=[a-zA-Z0-9\-]*" /proc/cmdline | cut -d "=" -f2)
+# these two env variables hold keyboard information
+export KEY=\${KEY:-us}
+export LOADKEY=\${LOADKEY:-us}
+
+# set the console filedescripor key layout
+loadkeys "\$LOADKEY"
+echo "KEYMAP=\$LOADKEY" >/etc/vconsole.conf
+EOF
 
 echo "$version" >/etc/version
 

--- a/toslive/customize_airootfs.sh_server
+++ b/toslive/customize_airootfs.sh_server
@@ -27,7 +27,7 @@ systemctl set-default multi-user.target
 systemctl enable NetworkManager
 
 if [[ $(ping -c1 1.1.1.1 | grep "0% packet loss") == "" ]]; then
-	wifi-menu
+  wifi-menu
 fi
 
 cd
@@ -53,7 +53,7 @@ git clone https://github.com/ODEX-TOS/zsh-load /root/.oh-my-zsh/load
 sed -i 's;setxkbmap $KEY;;' /root/.oh-my-zsh/load/etc.sh
 
 # set the default keymap to us (get overridden by .profile)
-printf 'KEYMAP=us' >/etc/vconsole.conf 
+printf 'KEYMAP=us' >/etc/vconsole.conf
 
 curl https://raw.githubusercontent.com/ODEX-TOS/tos-live/master/_tos >/root/.oh-my-zsh/custom/plugins/zsh-completions/src/_tos
 
@@ -83,11 +83,11 @@ HOME_URL="https://tos.pbfp.xyz/"
 LOGO=toslinux' >/etc/os-release
 
 if [[ -f "/root/tos" ]]; then
-	rm /root/tos
+  rm /root/tos
 fi
 
 # get the keymapping from /proc/cmdline
-cat <<EOF >> /root/.profile
+cat <<EOF >>/root/.profile
 KEY=\$(grep -o "tos.key=[a-zA-Z0-9\-]*" /proc/cmdline | cut -d "=" -f2)
 LOADKEY=\$(grep -o "tos.loadkeys=[a-zA-Z0-9\-]*" /proc/cmdline | cut -d "=" -f2)
 # these two env variables hold keyboard information
@@ -101,7 +101,7 @@ EOF
 
 # enable sysrq triggers
 mkdir -p /etc/sysctl.d/
-echo "kernel.sysrq = 511" >> /etc/sysctl.d/99-sysctl.conf
+echo "kernel.sysrq = 511" >>/etc/sysctl.d/99-sysctl.conf
 pacman-key --init
 pacman-key --populate archlinux
 pacman-key --populate tos

--- a/toslive/customize_airootfs.sh_server
+++ b/toslive/customize_airootfs.sh_server
@@ -2,7 +2,6 @@
 
 set -e -u
 
-azerty="0"
 version="v0.0.0"
 
 sed -i 's/#\(en_US\.UTF-8\)/\1/' /etc/locale.gen
@@ -22,9 +21,6 @@ sed -i 's/#\(Storage=\)auto/\1volatile/' /etc/systemd/journald.conf
 sed -i 's/#\(HandleSuspendKey=\)suspend/\1ignore/' /etc/systemd/logind.conf
 sed -i 's/#\(HandleHibernateKey=\)hibernate/\1ignore/' /etc/systemd/logind.conf
 sed -i 's/#\(HandleLidSwitch=\)suspend/\1ignore/' /etc/systemd/logind.conf
-if [[ "$azerty" == "1" ]]; then
-	loadkeys be-latin1
-fi
 
 systemctl enable pacman-init.service choose-mirror.service
 systemctl set-default multi-user.target
@@ -54,12 +50,11 @@ git clone https://github.com/zsh-users/zsh-syntax-highlighting.git /root/.oh-my-
 git clone https://github.com/zsh-users/zsh-completions.git /root/.oh-my-zsh/custom/plugins/zsh-completions
 
 git clone https://github.com/ODEX-TOS/zsh-load /root/.oh-my-zsh/load
-if [[ "$azerty" == "0" ]]; then
-	sed -i 's;setxkbmap $KEY;;' /root/.oh-my-zsh/load/etc.sh
-    printf 'KEYMAP=us' > /etc/vconsole.conf
-else
-    printf 'KEYMAP=be-latin1' > /etc/vconsole.conf
-fi
+sed -i 's;setxkbmap $KEY;;' /root/.oh-my-zsh/load/etc.sh
+
+# set the default keymap to us (get overridden by .profile)
+printf 'KEYMAP=us' >/etc/vconsole.conf 
+
 curl https://raw.githubusercontent.com/ODEX-TOS/tos-live/master/_tos >/root/.oh-my-zsh/custom/plugins/zsh-completions/src/_tos
 
 curl https://raw.githubusercontent.com/ODEX-TOS/dotfiles/master/.zshrc >/root/.zshrc
@@ -91,10 +86,18 @@ if [[ -f "/root/tos" ]]; then
 	rm /root/tos
 fi
 
-if [[ "$azerty" == "1" ]]; then
-	echo "loadkeys be-latin1" >>/root/.profile
-	echo "export KEY='be'" >>/root/.profile
-fi
+# get the keymapping from /proc/cmdline
+cat <<EOF >> /root/.profile
+KEY=\$(grep -o "tos.key=[a-zA-Z0-9\-]*" /proc/cmdline | cut -d "=" -f2)
+LOADKEY=\$(grep -o "tos.loadkeys=[a-zA-Z0-9\-]*" /proc/cmdline | cut -d "=" -f2)
+# these two env variables hold keyboard information
+export KEY=\${KEY:-us}
+export LOADKEY=\${LOADKEY:-us}
+
+# set the console filedescripor key layout
+loadkeys "\$LOADKEY"
+echo "KEYMAP=\$LOADKEY" >/etc/vconsole.conf
+EOF
 
 # enable sysrq triggers
 mkdir -p /etc/sysctl.d/

--- a/toslive/start.sh
+++ b/toslive/start.sh
@@ -41,7 +41,7 @@ function build() {
     yay -Syu mkinitcpio-archiso || exit 1
   fi
 
-  # do a complete remove of the working directory since we are building 2 different version in it
+  # do a complete remove of the working directory since we are building multiple different version using it
   rm -rf work
 
   ./build.sh -v || exit 1
@@ -62,44 +62,15 @@ function build() {
     mkdir -p images/awesome
   fi
 
-  if [[ "$1" == "-g" ]]; then
-    if [[ "$2" == "-a" ]]; then
-      cp out/toslinux*.iso images/client/"$iso_azerty""$append".iso
-      mv out/toslinux*.iso out/toslive-azerty.iso
-    else
-      cp out/toslinux*.iso images/client/"$iso_normal""$append".iso
-      mv out/toslinux*.iso out/toslive.iso
-    fi
-  fi
-
-  if [[ "$1" == "-k" ]]; then
-    if [[ "$2" == "-a" ]]; then
-      cp out/toslinux*.iso images/kde/"$iso_azerty""$append".iso
-      mv out/toslinux*.iso out/toslive-kde-azerty.iso
-    else
-      cp out/toslinux*.iso images/kde/"$iso_normal""$append".iso
-      mv out/toslinux*.iso out/toslive-kde.iso
-    fi
-  fi
 
   if [[ "$1" == "-awesome" ]]; then
-    if [[ "$2" == "-a" ]]; then
-      cp out/toslinux*.iso images/awesome/"$iso_azerty""$append".iso
-      mv out/toslinux*.iso out/toslive-awesome-azerty.iso
-    else
-      cp out/toslinux*.iso images/awesome/"$iso_normal""$append".iso
-      mv out/toslinux*.iso out/toslive-awesome.iso
-    fi
+    cp out/toslinux*.iso images/awesome/"$iso_normal""$append".iso
+    mv out/toslinux*.iso out/toslive-awesome.iso
   fi
 
   if [[ "$1" == "-s" ]]; then
-    if [[ "$2" == "-a" ]]; then
-      cp out/toslinux*.iso images/server/"$iso_azerty""$append".iso
-      mv out/toslinux*.iso out/tosserver-azerty.iso
-    else
-      cp out/toslinux*.iso images/server/"$iso_normal""$append".iso
-      mv out/toslinux*.iso out/tosserver.iso
-    fi
+    cp out/toslinux*.iso images/server/"$iso_normal""$append".iso
+    mv out/toslinux*.iso out/tosserver.iso
   fi
 
 }
@@ -107,19 +78,12 @@ function build() {
 if [[ "$1" == "-h" ]]; then
   echo "-h | help message"
   echo "-s | compile iso in server mode"
-  echo "-g | compile iso in gui mode "
-  echo "-k | compile iso in kde mode "
   echo "-awesome | compile iso in awesome mode "
-  echo "-a | compile iso with azerty as keyboard layout (works with all other modes) This option must be the last option specified "
   exit 0
 fi
 
-if [[ "$1" == "-g" ]]; then
-  cp customize_airootfs.sh_client airootfs/root/customize_airootfs.sh || exit 1
-elif [[ "$1" == "-s" ]]; then
+if [[ "$1" == "-s" ]]; then
   cp customize_airootfs.sh_server airootfs/root/customize_airootfs.sh || exit 1
-elif [[ "$1" == "-k" ]]; then
-  cp customize_airootfs.sh_kde airootfs/root/customize_airootfs.sh || exit 1
 elif [[ "$1" == "-awesome" ]]; then
   cp customize_airootfs.sh_awesome airootfs/root/customize_airootfs.sh || exit 1
 fi
@@ -128,7 +92,6 @@ if [[ "$2" == "-a" ]]; then
   sed -i 's;azerty="0";azerty="1";' airootfs/root/customize_airootfs.sh || exit 1
 else
   append="$2"
-  sed -i 's;azerty="1";azerty="0";' airootfs/root/customize_airootfs.sh || exit 1
 fi
 
 if [[ "$3" != "" ]]; then
@@ -136,29 +99,13 @@ if [[ "$3" != "" ]]; then
 fi
 echo "$append"
 
-if [[ "$1" == "-g" ]]; then
-  sed -i 's;gui="0";gui="1";' airootfs/root/customize_airootfs.sh
-  sed -i -r 's;version=".*";version="'"$version"'";' airootfs/root/customize_airootfs.sh
-  cp packages.x86_64_client packages.x86_64
-  build "$1" "$2"
-fi
-
-if [[ "$1" == "-k" ]]; then
-  sed -i 's;gui="0";gui="1";' airootfs/root/customize_airootfs.sh
-  sed -i -r 's;version=".*";version="'"$version"'";' airootfs/root/customize_airootfs.sh
-  cp packages.x86_64_kde packages.x86_64
-  build "$1" "$2"
-fi
-
 if [[ "$1" == "-awesome" ]]; then
-  sed -i 's;gui="0";gui="1";' airootfs/root/customize_airootfs.sh
   sed -i -r 's;version=".*";version="'"$version"'";' airootfs/root/customize_airootfs.sh
   cp packages.x86_64_awesome packages.x86_64
   build "$1" "$2"
 fi
 
 if [[ "$1" == "-s" ]]; then
-  sed -i 's;gui="1";gui="0";' airootfs/root/customize_airootfs.sh
   sed -i -r 's;version=".*";version="'"$version"'";' airootfs/root/customize_airootfs.sh
   cp packages.x86_64_server packages.x86_64
   build "$1" "$2"

--- a/toslive/start.sh
+++ b/toslive/start.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
 # MIT License
-# 
+#
 # Copyright (c) 2019 Meyers Tom
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -62,7 +62,6 @@ function build() {
     mkdir -p images/awesome
   fi
 
-
   if [[ "$1" == "-awesome" ]]; then
     cp out/toslinux*.iso images/awesome/"$iso_normal""$append".iso
     mv out/toslinux*.iso out/toslive-awesome.iso
@@ -110,5 +109,3 @@ if [[ "$1" == "-s" ]]; then
   cp packages.x86_64_server packages.x86_64
   build "$1" "$2"
 fi
-
-

--- a/toslive/syslinux/archiso_sys.cfg
+++ b/toslive/syslinux/archiso_sys.cfg
@@ -8,6 +8,17 @@ ENDTEXT
 MENU LABEL Boot TOS GNU/Linux (x86_64)
 LINUX boot/x86_64/vmlinuz
 INITRD boot/intel_ucode.img,boot/amd_ucode.img,boot/x86_64/archiso.img
-APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=1G
+APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=1G tos.key=us tos.loadkeys=us
+
+LABEL arch64-azerty
+TEXT HELP
+Boot the TOS GNU/Linux (x86_64) live medium.
+It allows you to install TOS GNU/Linux or perform system maintenance.
+ENDTEXT
+MENU LABEL Boot TOS GNU/Linux (x86_64) - AZERTY
+LINUX boot/x86_64/vmlinuz
+INITRD boot/intel_ucode.img,boot/amd_ucode.img,boot/x86_64/archiso.img
+APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=1G tos.key=be tos.loadkeys=be-latin1
+
 
 INCLUDE boot/syslinux/archiso_tail.cfg


### PR DESCRIPTION
Select the keyboard layout from systemd-boot

We provide the following command line options
```
tos.key=us
tos.loadkeys=us
```

Here is what each option does
- `tos.key` describes the keyboard layout to be used by the graphical environment
- `tos.loadkeys` sets the console keyboard layout as described in the keymaps